### PR TITLE
Avoid lookup of unsupported classes

### DIFF
--- a/app/src/main/java/tn/amin/keyboard_gpt/hook/HookManager.java
+++ b/app/src/main/java/tn/amin/keyboard_gpt/hook/HookManager.java
@@ -49,7 +49,7 @@ public class HookManager {
     private Method findMethod(Class<?> clazz, String methodName, Class<?>[] paramTypes) {
         try {
             return XposedHelpers.findMethodBestMatch(clazz, methodName, paramTypes);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             MainHook.log("XposedHelpers API could not find " + clazz.getName() + "."  + methodName
                     + " because of (" +
                     e.getClass().getName() + " : " + e.getMessage() +

--- a/app/src/main/java/tn/amin/keyboard_gpt/hook/HookManager.java
+++ b/app/src/main/java/tn/amin/keyboard_gpt/hook/HookManager.java
@@ -1,5 +1,7 @@
 package tn.amin.keyboard_gpt.hook;
 
+import android.os.Build;
+
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -10,17 +12,22 @@ import java.util.function.Predicate;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
+import tn.amin.keyboard_gpt.MainHook;
 
 public class HookManager {
     private Map<Method, XC_MethodHook.Unhook> unhookMap = new HashMap<>();
 
     public void hook(Class<?> clazz, String methodName, Class<?>[] paramTypes, XC_MethodHook callback) {
-        Method method = XposedHelpers.findMethodBestMatch(clazz, methodName, paramTypes);
+        Method method = findMethod(clazz, methodName, paramTypes);
         if (!unhookMap.containsKey(method)) {
             unhookMap.put(method, XposedBridge.hookMethod(method, callback));
         }
     }
 
+    /*
+    * Deprecated because using getDeclaredMethods in Gboard can cause NoClassDefFoundError
+    * */
+    @Deprecated
     public void hookAll(Class<?> clazz, String methodName, XC_MethodHook callback) {
         for (Method method : clazz.getDeclaredMethods()) {
             if (method.getName().equals(methodName)) {
@@ -35,6 +42,23 @@ public class HookManager {
         for (Method method: unhookMap.keySet()) {
             if (clearPredicate.test(method)) {
                 unhookMap.remove(method).unhook();
+            }
+        }
+    }
+
+    private Method findMethod(Class<?> clazz, String methodName, Class<?>[] paramTypes) {
+        try {
+            return XposedHelpers.findMethodBestMatch(clazz, methodName, paramTypes);
+        } catch (Exception e) {
+            MainHook.log("XposedHelpers API could not find " + clazz.getName() + "."  + methodName
+                    + " because of (" +
+                    e.getClass().getName() + " : " + e.getMessage() +
+                    "). Falling back to standard java API");
+
+            try {
+                return clazz.getMethod(methodName, paramTypes);
+            } catch (NoSuchMethodException e2) {
+                throw new RuntimeException(e2);
             }
         }
     }


### PR DESCRIPTION
Some keyboards like Gboard have functions declared with classes that might be unsupported in older android versions.
This PR addresses this issue, by preventing accidental lookup of one of these classes, which might cause `NoClassDefFoundError`. And that can lead to crashes and malfunctioning of the module.

Resolves #41 (Thanks @AbsolutUser for the detailed log)
